### PR TITLE
Fixed parameter list for pink so it actually works.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-02-14 Dason Kurkiewicz  <dasonk@iastate.edu>
+
+    * R/foass.R: Fixed parameter list for pink so it actually works.
+
 2014-01-21  Dirk Eddelbuettel  <edd@debian.org>
 
 	* R/foaas.R: New accessor function madison(name, from) but

--- a/R/foaas.R
+++ b/R/foaas.R
@@ -17,7 +17,7 @@ donut       <- function(name, from) { .foaas("donut", name, from) }
 shakespeare <- function(name, from) { .foaas("shakespeare", name, from) }
 linus       <- function(name, from) { .foaas("linus", name, from) }
 king        <- function(name, from) { .foaas("king", name, from) }
-pink        <- function(name, from) { .foaas("pink", name, from) }
+pink        <- function(name)       { .foaas("pink", name) }
 life        <- function(name)       { .foaas("life", name) }
 chainsaw    <- function(name, from) { .foaas("chainsaw", name, from) }
 thing       <- function(name, from) { .foaas(name, from) }


### PR DESCRIPTION
Previously it took 'name' and 'to' but pink only accepts a 'name'.
