### PR TITLE
Printallfos

### DIFF
--- a/demo/00Index
+++ b/demo/00Index
@@ -1,0 +1,1 @@
+printallfos    Print all exclamation in the rfoaas package with a consistent set of names; illustration of computing on the language

--- a/demo/printallfos.R
+++ b/demo/printallfos.R
@@ -1,0 +1,25 @@
+printallfos <- function(name='NAME', from='FROM', tool='R',
+                        company='YOYODYNE', do='DEBUG',
+                        something='R', reference='REFERENCE',
+                        reaction='SWITCH TO R',
+                        short=TRUE) {
+    y <- lsf.str('package:rfoaas')
+    y <- y[-which(y %in% c('operations', 'print.rfoaas', 'version'))]
+    argnames <- names(formals())
+    out <- list()
+    if (short) y <- c('ballmer', 'madison')
+    for (i in y) {
+        arglist <- list()
+        fnargs <- names(formals(i))
+        for (j in argnames)
+            if (length(grep(j, fnargs))>0) arglist[[j]] <- get(j)
+        out[[i]] <- do.call(i, arglist)
+    }
+    return(out)
+}
+
+printallfos(short=TRUE)
+
+
+
+

--- a/man/rfoaas-package.Rd
+++ b/man/rfoaas-package.Rd
@@ -234,6 +234,31 @@
     ## operations() returns JSON object listing the accessible functionality
     if (require(jsonlite)) print(fromJSON(operations()))
 
+    ## get all accessors in the package
+    ## Be careful as this creates a load on rfoaas.org
+    printallfos <- function(name='NAME', from='FROM', tool='R',
+                        company='YOYODYNE', do='DEBUG',
+                        something='R', reference='REFERENCE',
+                        reaction='SWITCH TO R') {
+    y <- lsf.str('package:rfoaas')
+    y <- y[-which(y %in% c('operations', 'print.rfoaas', 'version'))]
+    argnames <- names(formals())
+    out <- list()
+    ## Enable one of the two next lines
+    ## following gets just three exclamations:
+    ## for (i in c('ballmer', 'shakespeare', 'madison')) {
+    ## get all exclamations 
+    for (i in y) {          
+        arglist <- list()
+        fnargs <- names(formals(i))
+        for (j in argnames)
+            if (length(grep(j, fnargs))>0) arglist[[j]] <- get(j)
+        out[[i]] <- do.call(i, arglist)
+    }
+    return(out)
+}
+
+
 }
 }
 \keyword{package}

--- a/man/rfoaas-package.Rd
+++ b/man/rfoaas-package.Rd
@@ -234,31 +234,8 @@
     ## operations() returns JSON object listing the accessible functionality
     if (require(jsonlite)) print(fromJSON(operations()))
 
-    ## get all accessors in the package
-    ## Be careful as this creates a load on rfoaas.org
-    printallfos <- function(name='NAME', from='FROM', tool='R',
-                        company='YOYODYNE', do='DEBUG',
-                        something='R', reference='REFERENCE',
-                        reaction='SWITCH TO R') {
-    y <- lsf.str('package:rfoaas')
-    y <- y[-which(y %in% c('operations', 'print.rfoaas', 'version'))]
-    argnames <- names(formals())
-    out <- list()
-    ## Enable one of the two next lines
-    ## following gets just three exclamations:
-    ## for (i in c('ballmer', 'shakespeare', 'madison')) {
-    ## get all exclamations 
-    for (i in y) {          
-        arglist <- list()
-        fnargs <- names(formals(i))
-        for (j in argnames)
-            if (length(grep(j, fnargs))>0) arglist[[j]] <- get(j)
-        out[[i]] <- do.call(i, arglist)
-    }
-    return(out)
-    }
     }
     
 }
-}
+
 \keyword{package} 

--- a/man/rfoaas-package.Rd
+++ b/man/rfoaas-package.Rd
@@ -235,7 +235,5 @@
     if (require(jsonlite)) print(fromJSON(operations()))
 
     }
-    
 }
-
 \keyword{package} 

--- a/man/rfoaas-package.Rd
+++ b/man/rfoaas-package.Rd
@@ -256,9 +256,9 @@
         out[[i]] <- do.call(i, arglist)
     }
     return(out)
-}
-
-
+    }
+    }
+    
 }
 }
 \keyword{package}

--- a/man/rfoaas-package.Rd
+++ b/man/rfoaas-package.Rd
@@ -261,4 +261,4 @@
     
 }
 }
-\keyword{package}
+\keyword{package} 


### PR DESCRIPTION
printallfos() removed from the .Rd file and created as a demo. The default is to print only ballmer and madison, but printallfos(short=FALSE) will print everything.